### PR TITLE
Fix. User 관련 Cache 제거

### DIFF
--- a/front/src/components/UI/molecules/NavList/UserNavList.tsx
+++ b/front/src/components/UI/molecules/NavList/UserNavList.tsx
@@ -35,10 +35,7 @@ const NavList = () => {
   const [signOutMutation, { client }] = useMutation<ISignOut>(SIGN_OUT, {
     onCompleted({ signout }) {
       if (signout.ok) {
-        client.cache.evict({
-          id: "ROOT_QUERY",
-          fieldName: "getUserInfo",
-        });
+        client.clearStore();
         setUserInfo(null);
         router.push("/");
       }

--- a/front/src/components/pages/WritePost/WritePost.tsx
+++ b/front/src/components/pages/WritePost/WritePost.tsx
@@ -59,7 +59,7 @@ const WritePost = ({ post }: IProps) => {
   const [addPostMutation, { client }] = useMutation<IAddPost, IAddPostVariables>(ADD_POST, {
     onCompleted({ addPost }) {
       if (addPost.ok) {
-        client.cache.reset();
+        client.clearStore();
         router.push("/");
       }
     },
@@ -68,7 +68,7 @@ const WritePost = ({ post }: IProps) => {
   const [editPostMutation] = useMutation<IEditPost, IEditPostVariables>(EDIT_POST, {
     onCompleted({ editPost }) {
       if (editPost.ok) {
-        client.cache.reset();
+        client.clearStore();
         router.push("/");
       }
     },

--- a/front/src/components/pages/WriteProject/WriteProject.tsx
+++ b/front/src/components/pages/WriteProject/WriteProject.tsx
@@ -72,7 +72,7 @@ const WriteProject = ({ project }: IProps) => {
   const movePageToProject = <T extends CoreResponse>(data: T) => {
     if (!data.ok) return;
 
-    client.cache.reset();
+    client.clearStore();
     router.push("/project");
   };
 

--- a/front/src/lib/checkTemporaryByUser.ts
+++ b/front/src/lib/checkTemporaryByUser.ts
@@ -1,12 +1,12 @@
 import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
-import { GET_USER_INFO } from "@queries/users";
 import { IGetUserInfo } from "@queries-types/users";
+import { GET_USER_INFO_OPTION } from "./initializeSigninCheck";
 
 export const checkTemporaryByUser = async (
   apolloClient: ApolloClient<NormalizedCacheObject>,
   isTemporary: boolean,
 ) => {
-  const { data } = await apolloClient.query<IGetUserInfo>({ query: GET_USER_INFO });
+  const { data } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   if (!data?.getUserInfo.username && isTemporary) return true;
 

--- a/front/src/lib/initializeSigninCheck.ts
+++ b/front/src/lib/initializeSigninCheck.ts
@@ -1,14 +1,18 @@
 import { GET_USER_INFO } from "@queries/users";
 import { setUserInfo } from "@store/userInfo";
 import { IGetUserInfo } from "@queries-types/users";
+import { QueryOptions } from "@apollo/client";
 import { initializeClient } from "./apollo";
+
+export const GET_USER_INFO_OPTION: QueryOptions = {
+  query: GET_USER_INFO,
+  fetchPolicy: "no-cache",
+};
 
 const initializeSigninCheck = async () => {
   const apolloClient = initializeClient();
 
-  const { data } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   if (data?.getUserInfo?.ok) setUserInfo(data.getUserInfo.username);
   else setUserInfo(null);

--- a/front/src/pages/temporary/index.ts
+++ b/front/src/pages/temporary/index.ts
@@ -1,11 +1,11 @@
 import { addApolloState } from "@lib/addApolloState";
 import { initializeClient } from "@lib/apollo";
+import { GET_USER_INFO_OPTION } from "@lib/initializeSigninCheck";
 import { IGetPosts, IGetPostsVariables } from "@queries-types/posts";
 import { IGetProjects } from "@queries-types/project";
 import { IGetUserInfo } from "@queries-types/users";
 import { GET_POSTS } from "@queries/post";
 import { GET_PROJECTS } from "@queries/project";
-import { GET_USER_INFO } from "@queries/users";
 import { GetServerSideProps } from "next";
 
 export { default } from "@pages/Temporary";
@@ -13,9 +13,7 @@ export { default } from "@pages/Temporary";
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const apolloClient = initializeClient({ ctx });
 
-  const { data: userData } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data: userData } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   if (!userData) {
     return {

--- a/front/src/pages/write/post/[id]/index.ts
+++ b/front/src/pages/write/post/[id]/index.ts
@@ -1,10 +1,10 @@
 import { GetServerSideProps } from "next";
 import { initializeClient } from "@lib/apollo";
-import { GET_USER_INFO } from "@queries/users";
 import { IGetUserInfo } from "@queries-types/users";
 import { addApolloState } from "@lib/addApolloState";
 import { IGetPost } from "@queries-types/posts";
 import { GET_POST } from "@queries/post/getPost.queries";
+import { GET_USER_INFO_OPTION } from "@lib/initializeSigninCheck";
 
 export { default } from "@pages/WritePost";
 
@@ -12,9 +12,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { query } = ctx;
   const apolloClient = initializeClient({ ctx });
 
-  const { data } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   const { data: postData } = await apolloClient.query<IGetPost>({
     query: GET_POST,

--- a/front/src/pages/write/post/index.ts
+++ b/front/src/pages/write/post/index.ts
@@ -1,17 +1,15 @@
 import { GetServerSideProps } from "next";
 import { initializeClient } from "@lib/apollo";
-import { GET_USER_INFO } from "@queries/users";
 import { IGetUserInfo } from "@queries-types/users";
 import { addApolloState } from "@lib/addApolloState";
+import { GET_USER_INFO_OPTION } from "@lib/initializeSigninCheck";
 
 export { default } from "@pages/WritePost";
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const apolloClient = initializeClient({ ctx });
 
-  const { data } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   if (!data)
     return {

--- a/front/src/pages/write/project/[id]/index.ts
+++ b/front/src/pages/write/project/[id]/index.ts
@@ -1,10 +1,10 @@
 import { GetServerSideProps } from "next";
 import { initializeClient } from "@lib/apollo";
-import { GET_USER_INFO } from "@queries/users";
 import { IGetUserInfo } from "@queries-types/users";
 import { addApolloState } from "@lib/addApolloState";
 import { IGetProject } from "@queries-types/project";
 import { GET_PROJECT } from "@queries/project/getProject.queries";
+import { GET_USER_INFO_OPTION } from "@lib/initializeSigninCheck";
 
 export { default } from "@pages/WriteProject";
 
@@ -12,9 +12,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { query } = ctx;
   const apolloClient = initializeClient({ ctx });
 
-  const { data: userData } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data: userData } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   const { data: projectData } = await apolloClient.query<IGetProject>({
     query: GET_PROJECT,

--- a/front/src/pages/write/project/index.ts
+++ b/front/src/pages/write/project/index.ts
@@ -1,17 +1,15 @@
 import { GetServerSideProps } from "next";
 import { initializeClient } from "@lib/apollo";
-import { GET_USER_INFO } from "@queries/users";
 import { IGetUserInfo } from "@queries-types/users";
 import { addApolloState } from "@lib/addApolloState";
+import { GET_USER_INFO_OPTION } from "@lib/initializeSigninCheck";
 
 export { default } from "@pages/WriteProject";
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const apolloClient = initializeClient({ ctx });
 
-  const { data } = await apolloClient.query<IGetUserInfo>({
-    query: GET_USER_INFO,
-  });
+  const { data } = await apolloClient.query<IGetUserInfo>(GET_USER_INFO_OPTION);
 
   if (!data)
     return {


### PR DESCRIPTION
- 여러 브라우저에서 로그인시 캐시 데이터를 가져오는 문제
- User 관련 정보를 가져올 땐 `fetchPolicy: "no-cache"`를 통해 캐시를 저장하지 않음