### PR TITLE
Transaction Decorator 적용

### DIFF
--- a/back/src/common/module/mongo.module.ts
+++ b/back/src/common/module/mongo.module.ts
@@ -1,18 +1,28 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
+
+import { ConnectionStore } from '@utils/ConnectionStore';
+import { transactionPlugin } from '@utils/mongoosePluginCb';
 
 @Module({
   imports: [
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
-        uri: `mongodb://${configService.get('DB_HOST')}:${configService.get(
-          'DB_PORT',
-        )}`,
+        uri: configService.get('DB_URI'),
         dbName: configService.get('DB_NAME'),
         user: configService.get('DB_USERNAME'),
         pass: configService.get('DB_PASSWORD'),
+
+        connectionFactory: (connection: Connection) => {
+          connection.plugin(transactionPlugin);
+
+          new ConnectionStore().setConnection(connection);
+
+          return connection;
+        },
       }),
       inject: [ConfigService],
     }),

--- a/back/src/decorators/transaction.decorator.ts
+++ b/back/src/decorators/transaction.decorator.ts
@@ -1,0 +1,44 @@
+import { InternalServerErrorException } from '@nestjs/common';
+
+import { ALS } from '@utils/AsyncLocalStorage';
+import { ConnectionStore } from '@utils/ConnectionStore';
+import { TRANSACTION_SESSION } from '@utils/constants';
+
+export function Transactional(): MethodDecorator {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<any>,
+  ) => {
+    const originalMethod = descriptor.value;
+    const als = new ALS();
+
+    descriptor.value = async function (...args: any[]) {
+      return als.run(async () => {
+        const connection = new ConnectionStore().getConnection();
+
+        if (!connection) {
+          throw new InternalServerErrorException("Can't find connection");
+        }
+
+        const session = await connection.startSession();
+        als.set(TRANSACTION_SESSION, session);
+
+        try {
+          let result: any;
+
+          await session.withTransaction(async () => {
+            result = await originalMethod.apply(this, args);
+          });
+
+          return result;
+        } catch (error) {
+          throw error;
+        } finally {
+          session.endSession();
+        }
+      });
+    };
+    return descriptor;
+  };
+}

--- a/back/src/posts/post.service.ts
+++ b/back/src/posts/post.service.ts
@@ -1,6 +1,7 @@
 import { NotFoundException, Inject, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 
+import { Transactional } from '@decorators/transaction.decorator';
 import { TagService } from '@tags/tag.service';
 import { getQueryOptionsByPost } from '@utils/getQueryOptionsByPost';
 
@@ -18,6 +19,7 @@ export class PostService {
     private readonly postRepository: PostRepository,
   ) {}
 
+  @Transactional()
   async createPost({ tags, ...info }: CreatePostInput) {
     const post = await this.postRepository.createPost({ ...info });
 
@@ -34,6 +36,7 @@ export class PostService {
     return post;
   }
 
+  @Transactional()
   async editPost(input: EditPostInput) {
     const { _id, addTags, deleteTags } = input;
 
@@ -57,6 +60,7 @@ export class PostService {
     return updatedPost;
   }
 
+  @Transactional()
   async deletePost(_id: string) {
     await this.postRepository.deletePost(_id);
     await this.tagService.deleteManyByPostId(_id);
@@ -95,6 +99,8 @@ export class PostService {
       };
     }
 
-    return this.postRepository.getPosts(where, limit);
+    const posts = await this.postRepository.getPosts(where, limit);
+
+    return posts;
   }
 }

--- a/back/src/tags/tag.service.ts
+++ b/back/src/tags/tag.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery } from 'mongoose';
 
+import { Transactional } from '@decorators/transaction.decorator';
+
 import { Tag, TagDocument, TagModel } from './tag.model';
 import { TagRepository } from './tag.repository';
 
@@ -24,6 +26,7 @@ export class TagService {
     return await this.tagModel.updateOne({ _id }, query);
   }
 
+  @Transactional()
   async pushAndReturnTagsByPostId(tagNames: string[], postId: string) {
     const tags = await Promise.all(
       tagNames.map((tagName) => this.tagRepository.findOrCreate(tagName)),
@@ -34,6 +37,7 @@ export class TagService {
     return tags;
   }
 
+  @Transactional()
   async deletePostIdInTags(tags: string[], postId: string) {
     await this.tagRepository.deletePostIdInTags(tags, postId);
 
@@ -42,6 +46,7 @@ export class TagService {
     return afterUpdate;
   }
 
+  @Transactional()
   async deleteManyByPostId(_id: string) {
     await this.tagRepository.deleteManyByPostId(_id);
   }

--- a/back/src/utils/AsyncLocalStorage.ts
+++ b/back/src/utils/AsyncLocalStorage.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+class ALS {
+  private static instance: ALS = new ALS();
+  private asyncLocalStorage = new AsyncLocalStorage<Map<any, any>>();
+
+  constructor() {
+    return ALS.instance;
+  }
+
+  get store() {
+    return this.asyncLocalStorage.getStore();
+  }
+
+  async run(fn: (...args: any[]) => any): Promise<any> {
+    return await this.asyncLocalStorage.run(new Map(), fn);
+  }
+
+  set(key: any, value: any) {
+    return this.store?.set(key, value);
+  }
+
+  get<T>(key: any): T {
+    return this.store?.get(key);
+  }
+}
+
+export { ALS };

--- a/back/src/utils/ConnectionStore.ts
+++ b/back/src/utils/ConnectionStore.ts
@@ -1,0 +1,20 @@
+import { Connection } from 'mongoose';
+
+import { TRANSACTION_KEY } from './constants';
+
+export class ConnectionStore {
+  private static instance: ConnectionStore = new ConnectionStore();
+  private _connections: { [K: string]: Connection } = {};
+
+  constructor() {
+    return ConnectionStore.instance;
+  }
+
+  setConnection(connection: Connection, connectionName = TRANSACTION_KEY) {
+    this._connections[connectionName] = connection;
+  }
+
+  getConnection(connectionName: string = TRANSACTION_KEY) {
+    return this._connections[connectionName];
+  }
+}

--- a/back/src/utils/constants.ts
+++ b/back/src/utils/constants.ts
@@ -1,5 +1,14 @@
 import { PipelineStage } from 'mongoose';
 
+const enum EMiddlewareTypes {
+  document = 'document',
+  query = 'query',
+  aggregate = 'aggregate',
+  model = 'model',
+}
+
+type TMiddlewareType = keyof typeof EMiddlewareTypes;
+
 const GET_TAGS_OPTIONS: PipelineStage[] = [
   {
     $lookup: {
@@ -67,4 +76,30 @@ const GET_TAG_OPTIONS: PipelineStage[] = [
   },
 ];
 
-export { GET_TAGS_OPTIONS, GET_TAG_OPTIONS };
+const TRANSACTION_KEY = 'transaction';
+const TRANSACTION_SESSION = Symbol('transaction_session');
+
+const documentAndQueryMiddleware = ['updateOne', 'deleteOne'];
+
+const middlewareGroups = {
+  [EMiddlewareTypes.document]: ['save', ...documentAndQueryMiddleware],
+  [EMiddlewareTypes.query]: [
+    'deleteMany',
+    'updateMany',
+    'findOneAndDelete',
+    'findOneAndUpdate',
+  ],
+  [EMiddlewareTypes.aggregate]: ['aggregate'],
+  [EMiddlewareTypes.model]: ['insertMany'],
+};
+
+export {
+  GET_TAGS_OPTIONS,
+  GET_TAG_OPTIONS,
+  TRANSACTION_KEY,
+  TRANSACTION_SESSION,
+  documentAndQueryMiddleware,
+  middlewareGroups,
+  EMiddlewareTypes,
+  TMiddlewareType,
+};

--- a/back/src/utils/mongoosePluginCb.ts
+++ b/back/src/utils/mongoosePluginCb.ts
@@ -1,0 +1,68 @@
+import {
+  Model,
+  Schema,
+  ClientSession,
+  MongooseQueryMiddleware,
+  MongooseDocumentMiddleware,
+} from 'mongoose';
+
+import { ALS } from './AsyncLocalStorage';
+import {
+  TMiddlewareType,
+  EMiddlewareTypes,
+  middlewareGroups,
+  TRANSACTION_SESSION,
+  documentAndQueryMiddleware,
+} from './constants';
+
+function transactionPlugin(schema: Schema) {
+  for (const middlewareType in middlewareGroups) {
+    middlewareGroups[middlewareType as TMiddlewareType].forEach((method) => {
+      if (middlewareType === EMiddlewareTypes.model) {
+        overwriteMethod(schema, method);
+      } else if (
+        middlewareType === EMiddlewareTypes.document &&
+        documentAndQueryMiddleware.includes(method)
+      ) {
+        schema.pre(
+          method as MongooseDocumentMiddleware,
+          { document: true, query: true },
+          preCb,
+        );
+      } else {
+        schema.pre(method as MongooseQueryMiddleware, preCb);
+      }
+    });
+  }
+}
+
+function preCb(this: any, next: any) {
+  const als = new ALS();
+  const session = als.get<ClientSession>(TRANSACTION_SESSION);
+
+  if (session) this.$session?.(session) || this.session?.(session);
+
+  next();
+}
+
+function overwriteMethod(schema: Schema, method: string) {
+  if (middlewareGroups.model.includes(method)) {
+    const als = new ALS();
+
+    schema.statics[method] = function (...args: any) {
+      const session = als.get<ClientSession>(TRANSACTION_SESSION);
+
+      if (session) {
+        const options = args[1] || {};
+
+        if (!options?.session) {
+          args[1] = Object.assign(options, { session });
+        }
+      }
+
+      return Model[method].apply(this, args);
+    };
+  }
+}
+
+export { transactionPlugin };


### PR DESCRIPTION
-  Closes #80 

## ✨ **구현 기능 명세**
- Create, Update, Delete 시 Transaction 을 적용하기 위해 Transaction Decorator를 구현

## 🎁 **주목할 점**
### AsyncLocalStorage
- 비동기 실행 방식은 코드의 실행 순서를 보장하지 않습니다. 따라서 기존 Transaction 실행중 새로운 요청이 들어온다면 기존에 유지되던 session이 변경되는 현상이 발생합니다.
- 이를 위해 AsyncLocalStorage를 통해 각 동작에 대한 Session을 유지합니다.

### Mogoose Plugin
- mongoDB는 transaction 적용시 각 method마다 session을 주입해주어야합니다.
- 이를 plugin을 통해 코드 실행시점에서 AsyncLocalStorage에 저장된 session을 가져와 자동으로 주입하는 로직을 구현합니다.

## 😭 **어려웠던 점**
- AsyncLocalStorage적용전 동시에 여러 요청이 들어왔을 경우 기존 session이 유지되지 않는 현상이 발생하여 해결하는데 많은 시간이 걸렸습니다.


